### PR TITLE
Update ZuniswapV2Library.sol

### DIFF
--- a/src/ZuniswapV2Library.sol
+++ b/src/ZuniswapV2Library.sol
@@ -15,7 +15,6 @@ library ZuniswapV2Library {
         address tokenA,
         address tokenB
     ) public returns (uint256 reserveA, uint256 reserveB) {
-        (address token0, address token1) = sortTokens(tokenA, tokenB);
         (uint256 reserve0, uint256 reserve1, ) = IZuniswapV2Pair(
             pairFor(factoryAddress, token0, token1)
         ).getReserves();


### PR DESCRIPTION
`getReserves` calls `_sortTokens` on tokenA, tokenB, then calls `pairFor` where the tokens are sorted again unnecessarily.